### PR TITLE
Update stays-app - June 2026

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     
     <application
         android:label="360 Stays"
@@ -31,6 +34,37 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="the360ghar.com"
+                    android:pathPrefix="/stays" />
+
+                <data
+                    android:scheme="https"
+                    android:host="www.the360ghar.com"
+                    android:pathPrefix="/stays" />
+
+                <data
+                    android:scheme="https"
+                    android:host="app.the360ghar.com"
+                    android:pathPrefix="/stays" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="stays360" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access to capture photos of properties for listings and your profile.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This app needs location access to show nearby hotels and provide better search results.</string>
 	<key>NSLocationTemporaryUsageDescriptionDictionary</key>
@@ -35,6 +37,31 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app needs location access to show nearby hotels and provide better search results.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs microphone access if you choose to record video tours for your listing.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.a360ghar.stays</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stays360</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app needs permission to save photos to your library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app needs photo library access to select images for property listings and your profile.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use tracking to provide personalized stay recommendations and measure ad effectiveness.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:the360ghar.com</string>
+        <string>applinks:www.the360ghar.com</string>
+        <string>applinks:app.the360ghar.com</string>
+    </array>
+</dict>
+</plist>

--- a/lib/app/bindings/initial_binding.dart
+++ b/lib/app/bindings/initial_binding.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 
 import '../../config/app_config.dart';
 import 'package:stays_app/app/controllers/notification/notification_controller.dart';
+import '../data/services/deep_link_service.dart';
 import '../data/services/analytics_service.dart';
 import '../data/services/location_service.dart';
 import '../data/services/places_service.dart';
@@ -74,6 +75,9 @@ class InitialBinding extends Bindings {
       AnalyticsService(enabled: AppConfig.I.enableAnalytics),
       permanent: true,
     );
+
+    // Deep link service (receives initial link + live stream)
+    Get.put<DeepLinkService>(DeepLinkService(), permanent: true);
 
     // Property cache service for offline support
     Get.putAsync<PropertyCacheService>(() async {

--- a/lib/app/data/providers/users_provider.dart
+++ b/lib/app/data/providers/users_provider.dart
@@ -114,16 +114,6 @@ class UsersProvider extends BaseProvider {
     }
   }
 
-  Future<void> deleteAccount() async {
-    final response = await delete('/api/v1/users/account/');
-    if (!response.isOk) {
-      throw ApiException(
-        message: response.statusText ?? 'Failed to delete account',
-        statusCode: response.statusCode ?? 500,
-      );
-    }
-  }
-
   Future<void> registerDeviceToken({
     required String token,
     required String platform,

--- a/lib/app/data/repositories/profile_repository.dart
+++ b/lib/app/data/repositories/profile_repository.dart
@@ -59,6 +59,4 @@ class ProfileRepository {
   Future<String> uploadAvatar(File file) => _provider.uploadAvatar(file);
 
   Future<void> requestDataExport() => _provider.requestDataExport();
-
-  Future<void> deleteAccount() => _provider.deleteAccount();
 }

--- a/lib/app/data/services/deep_link_service.dart
+++ b/lib/app/data/services/deep_link_service.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:stays_app/app/routes/app_routes.dart';
+import 'package:stays_app/app/utils/logger/app_logger.dart';
+
+class DeepLinkService extends GetxService {
+  StreamSubscription? _sub;
+  final AppLinks _appLinks = AppLinks();
+  final Rxn<String> pendingDeepLink = Rxn<String>();
+
+  static const String _baseUrl = 'https://the360ghar.com';
+
+  @override
+  void onInit() {
+    super.onInit();
+    _initDeepLinks();
+  }
+
+  @override
+  void onClose() {
+    _sub?.cancel();
+    super.onClose();
+  }
+
+  Future<void> _initDeepLinks() async {
+    if (kIsWeb) return;
+
+    try {
+      final initialUri = await _appLinks.getInitialLink();
+      if (initialUri != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _handleDeepLink(initialUri);
+        });
+      }
+    } on PlatformException catch (e) {
+      AppLogger.warning('Failed to get initial deep link: $e');
+    }
+
+    _sub = _appLinks.uriLinkStream.listen(
+      (Uri? uri) {
+        if (uri != null) {
+          _handleDeepLink(uri);
+        }
+      },
+      onError: (Object err) {
+        AppLogger.error('Deep link stream error: $err');
+      },
+    );
+  }
+
+  void _handleDeepLink(Uri uri) {
+    AppLogger.info('🔗 Received Deep Link: $uri');
+
+    final internalPath = _mapToInternalPath(uri);
+
+    if (internalPath != null) {
+      AppLogger.info('🔗 Mapped to internal path: $internalPath');
+      _navigateToPath(internalPath);
+    } else {
+      AppLogger.warning('🔗 Could not parse deep link: $uri');
+    }
+  }
+
+  String? _mapToInternalPath(Uri uri) {
+    final segments = uri.pathSegments;
+    if (segments.isEmpty) return null;
+
+    final firstSegment = segments[0];
+
+    if (firstSegment == 'stays' && segments.length >= 2) {
+      return _mapStaysPrefix(segments.sublist(1));
+    }
+
+    if (firstSegment == 'listing' && segments.length >= 2) {
+      return _buildListingPath(segments[1]);
+    }
+
+    if (firstSegment == 'chat' && segments.length >= 2) {
+      return _buildChatPath(segments[1]);
+    }
+
+    return null;
+  }
+
+  String? _mapStaysPrefix(List<String> segments) {
+    if (segments.isEmpty) return null;
+
+    final subPath = segments[0];
+
+    if (subPath == 'listing' && segments.length >= 2) {
+      return _buildListingPath(segments[1]);
+    }
+
+    if (subPath == 'chat' && segments.length >= 2) {
+      return _buildChatPath(segments[1]);
+    }
+
+    return null;
+  }
+
+  String _buildListingPath(String listingId) =>
+      Routes.listingDetail.replaceAll(':id', listingId);
+
+  String _buildChatPath(String conversationId) =>
+      Routes.chat.replaceAll(':conversationId', conversationId);
+
+  void _navigateToPath(String path) {
+    pendingDeepLink.value = path;
+    Future.delayed(const Duration(milliseconds: 500), () {
+      try {
+        Get.toNamed(path);
+      } catch (e) {
+        AppLogger.error('🔗 Failed to navigate to deep link path: $path', e);
+        // If navigation fails (e.g. auth middleware redirects to login),
+        // the pendingDeepLink is preserved for post-login replay.
+      }
+    });
+  }
+
+  String? consumePendingDeepLink() {
+    final path = pendingDeepLink.value;
+    if (path != null) {
+      pendingDeepLink.value = null;
+      AppLogger.info('🔗 Consuming pending deep link: $path');
+    }
+    return path;
+  }
+
+  void navigateToPendingDeepLink() {
+    final path = consumePendingDeepLink();
+    if (path != null) {
+      Future.delayed(const Duration(milliseconds: 300), () {
+        Get.toNamed(path);
+      });
+    }
+  }
+
+  static String listingUrl(String listingId) =>
+      '$_baseUrl/stays/listing/$listingId';
+
+  static String chatUrl(String chatId) =>
+      '$_baseUrl/stays/chat/$chatId';
+}

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -258,5 +258,18 @@ class AppPages {
       binding: TripsBinding(),
       middlewares: [AuthMiddleware()],
     ),
+    // Deep link routes - no AuthMiddleware for public access from shared links
+    GetPage(
+      name: Routes.listingDeepLink,
+      page: () => const ListingDetailView(),
+      binding: ListingBinding(),
+      transition: Transition.rightToLeft,
+    ),
+    GetPage(
+      name: Routes.chatDeepLink,
+      page: () => const ChatView(),
+      binding: MessageBinding(),
+      transition: Transition.rightToLeft,
+    ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -34,6 +34,10 @@ abstract class Routes {
   static const profileFeedbackBug = '/profile/feedback/bug';
   static const profileFeedbackFeature = '/profile/feedback/feature';
 
+  // Deep link routes (no auth middleware for shared/public access)
+  static const listingDeepLink = '/listing/:id';
+  static const chatDeepLink = '/chat/:conversationId';
+
   // Backwards compatibility aliases (will be removed once consumers migrate)
   static const enquiry = inquiry; // British spelling alias
   static const enquiryConfirmation = inquiryConfirmation;

--- a/lib/app/utils/constants/app_constants.dart
+++ b/lib/app/utils/constants/app_constants.dart
@@ -18,4 +18,8 @@ class AppConstants {
   // These are intentionally centralized to avoid scattering magic numbers.
   static const double defaultLatitude = 19.0760; // Mumbai
   static const double defaultLongitude = 72.8777; // Mumbai
+
+  // Legal document URLs
+  static const String privacyPolicyUrl = 'https://360ghar.com/policies/privacy-policy';
+  static const String termsOfServiceUrl = 'https://360ghar.com/policies/terms-of-service';
 }

--- a/lib/features/home/views/simple_home_view.dart
+++ b/lib/features/home/views/simple_home_view.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
 import 'package:stays_app/app/ui/theme/app_animations.dart';
@@ -20,6 +21,7 @@ class SimpleHomeView extends StatefulWidget {
 
 class _SimpleHomeViewState extends State<SimpleHomeView> {
   late final NavigationController controller;
+  DateTime? _lastBackPress;
 
   @override
   void initState() {
@@ -33,32 +35,52 @@ class _SimpleHomeViewState extends State<SimpleHomeView> {
     final colorScheme = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
 
-    return Scaffold(
-      backgroundColor: colorScheme.surface,
-      extendBody: true,
-      body: PageView.builder(
-        controller: controller.pageController,
-        itemCount: 5,
-        onPageChanged: (index) {
-          controller.currentIndex.value = index;
-          if (index == 3 && Get.isRegistered<HotelsMapController>()) {
-            Get.find<HotelsMapController>().getCurrentLocation();
-          }
-        },
-        itemBuilder: (context, index) {
-          return switch (index) {
-            0 => const ExploreView(),
-            1 => const WishlistView(),
-            2 => InquiriesPage(),
-            3 => const LocateView(),
-            4 => const ProfileView(),
-            _ => const SizedBox.shrink(),
-          };
-        },
-      ),
-      bottomNavigationBar: _PremiumBottomNav(
-        controller: controller,
-        isDark: isDark,
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        final now = DateTime.now();
+        if (_lastBackPress != null &&
+            now.difference(_lastBackPress!) < const Duration(seconds: 3)) {
+          SystemNavigator.pop();
+        } else {
+          _lastBackPress = now;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Press back again to exit'),
+              duration: Duration(seconds: 3),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: colorScheme.surface,
+        extendBody: true,
+        body: PageView.builder(
+          controller: controller.pageController,
+          itemCount: 5,
+          onPageChanged: (index) {
+            controller.currentIndex.value = index;
+            if (index == 3 && Get.isRegistered<HotelsMapController>()) {
+              Get.find<HotelsMapController>().getCurrentLocation();
+            }
+          },
+          itemBuilder: (context, index) {
+            return switch (index) {
+              0 => const ExploreView(),
+              1 => const WishlistView(),
+              2 => InquiriesPage(),
+              3 => const LocateView(),
+              4 => const ProfileView(),
+              _ => const SizedBox.shrink(),
+            };
+          },
+        ),
+        bottomNavigationBar: _PremiumBottomNav(
+          controller: controller,
+          isDark: isDark,
+        ),
       ),
     );
   }
@@ -361,7 +383,7 @@ class _PremiumNavItemState extends State<_PremiumNavItem>
                   ),
                 ],
               );
-            },
+},
           ),
         ),
       ),

--- a/lib/features/profile/bindings/profile_binding.dart
+++ b/lib/features/profile/bindings/profile_binding.dart
@@ -117,6 +117,7 @@ class ProfileBinding extends Bindings {
           profileController: Get.find<ProfileController>(),
           authRepository: authRepository,
           authController: authController,
+          usersProvider: Get.find<UsersProvider>(),
         ),
         fenix: true,
       );

--- a/lib/features/profile/controllers/about_controller.dart
+++ b/lib/features/profile/controllers/about_controller.dart
@@ -11,11 +11,7 @@ class AboutController extends GetxController {
 
   final List<Map<String, String>> complianceItems = const [
     {'title': 'Terms & Conditions', 'route': Routes.legal, 'slug': 'terms'},
-    {
-      'title': 'Privacy Policy',
-      'route': Routes.profilePrivacy,
-      'slug': 'privacy-policy',
-    },
+    {'title': 'Privacy Policy', 'route': Routes.legal, 'slug': 'privacy'},
     {
       'title': 'Refund & Cancellation Policy',
       'route': Routes.profileHelp,

--- a/lib/features/profile/controllers/privacy_controller.dart
+++ b/lib/features/profile/controllers/privacy_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:stays_app/app/controllers/base/base_controller.dart';
+import 'package:stays_app/app/data/providers/users_provider.dart';
 import 'package:stays_app/features/auth/controllers/auth_controller.dart';
 import 'package:stays_app/app/data/models/user_model.dart';
 import 'package:stays_app/app/data/repositories/auth_repository.dart';
@@ -8,18 +9,20 @@ import 'package:stays_app/app/data/repositories/profile_repository.dart';
 import 'package:stays_app/app/routes/app_routes.dart';
 import 'package:stays_app/app/utils/extensions/dynamic_extensions.dart';
 import 'package:stays_app/app/utils/helpers/app_snackbar.dart';
+import 'package:stays_app/app/utils/logger/app_logger.dart';
 import 'package:stays_app/features/profile/controllers/profile_controller.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class PrivacyController extends BaseController {
-  PrivacyController({
-    required ProfileRepository profileRepository,
-    required ProfileController profileController,
-    required AuthRepository authRepository,
-    required AuthController authController,
-  }) : _profileRepository = profileRepository,
-       _profileController = profileController,
-       _authRepository = authRepository,
-       _authController = authController;
+PrivacyController({
+     required ProfileRepository profileRepository,
+     required ProfileController profileController,
+     required AuthRepository authRepository,
+     required AuthController authController,
+   }) : _profileRepository = profileRepository,
+        _profileController = profileController,
+        _authRepository = authRepository,
+        _authController = authController;
 
   final ProfileRepository _profileRepository;
   final ProfileController _profileController;
@@ -174,7 +177,8 @@ class PrivacyController extends BaseController {
           AlertDialog(
             title: const Text('Delete account'),
             content: const Text(
-              'This action cannot be undone. Do you really want to delete your account?',
+              'This action cannot be undone. All your data will be permanently deleted. '
+              'Are you sure you want to delete your account?',
             ),
             actions: [
               TextButton(
@@ -193,23 +197,50 @@ class PrivacyController extends BaseController {
     if (!confirmDeletion) return;
 
     accountDeletionInFlight.value = true;
-    final result = await executeWithErrorHandling(() async {
-      await _profileRepository.deleteAccount();
-      await _authController.logout();
-      return true;
-    }, showLoading: false);
-    accountDeletionInFlight.value = false;
-    if (result == true) {
-      Get.offAllNamed(Routes.login);
-      AppSnackbar.success(
-        title: 'Account deleted',
-        message: 'Your account has been removed successfully.',
-      );
-    } else {
+
+    const supportEmail = 'info@360ghar.com';
+    const subject = 'Account Deletion Request';
+    final userEmail = _profileController.user.value?.email;
+    final body = StringBuffer()
+      ..writeln('Hello 360 Ghar Support,')
+      ..writeln()
+      ..writeln('I would like to request the deletion of my account.')
+      ..writeln()
+      ..writeln('Registered email: ${userEmail ?? 'Not available'}')
+      ..writeln()
+      ..writeln('Thank you.');
+    final uri = Uri(
+      scheme: 'mailto',
+      path: supportEmail,
+      queryParameters: <String, String>{
+        'subject': subject,
+        'body': body.toString(),
+      },
+    );
+
+    try {
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (launched) {
+        AppSnackbar.success(
+          title: 'Request initiated',
+          message:
+              'Your mail app is opening. Please send the pre-filled email to complete your request.',
+        );
+      } else {
+        AppSnackbar.error(
+          title: 'Could not open mail app',
+          message:
+              'Please email $supportEmail with subject "$subject" from your registered address.',
+        );
+      }
+    } catch (e) {
       AppSnackbar.error(
-        title: 'Deletion failed',
-        message: 'We could not delete your account. Please contact support.',
+        title: 'Could not open mail app',
+        message:
+            'Please email $supportEmail with subject "$subject" from your registered address.',
       );
+    } finally {
+      accountDeletionInFlight.value = false;
     }
   }
 }

--- a/lib/features/profile/views/legal_view.dart
+++ b/lib/features/profile/views/legal_view.dart
@@ -1,80 +1,68 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:stays_app/app/utils/constants/app_constants.dart';
 
 class LegalView extends StatelessWidget {
   const LegalView({super.key});
 
-  static const _legalSections = [
-    {
-      'title': 'Terms & Conditions',
-      'body':
-          'By using 360ghar Stays you agree to follow local regulations, respect hosts and neighbours, and comply with our cancellation policies. Hosts are responsible for maintaining accurate listings and ensuring safe stays.',
-    },
-    {
-      'title': 'Privacy Policy',
-      'body':
-          'We collect only the information needed to provide inquiry services, kept secure via encrypted storage. Review your privacy preferences under Privacy & Security to control data sharing.',
-    },
-    {
-      'title': 'Refund & Cancellation Policy',
-      'body':
-          'Flexible cancellation is available up to 48 hours before check-in for most stays. Refunds are processed within 5-7 business days. Special events and non-refundable rates follow the listing rules.',
-    },
-    {
-      'title': 'Licenses & Compliance',
-      'body':
-          '360ghar Stays partners with verified hosts and adheres to regional tourism regulations. We work with local authorities to ensure guest safety and tax compliance.',
-    },
-  ];
+  static const Map<String, _LegalDocument> _documents = {
+    'terms': _LegalDocument(
+      title: 'Terms of Service',
+      url: AppConstants.termsOfServiceUrl,
+    ),
+    'privacy': _LegalDocument(
+      title: 'Privacy Policy',
+      url: AppConstants.privacyPolicyUrl,
+    ),
+  };
+
+  _LegalDocument _resolveDocument() {
+    final raw = Get.arguments;
+    final slug = raw is String ? raw.toLowerCase() : 'terms';
+    final key = _documents.keys.firstWhere(
+      (k) => slug == k || slug == '$k-policy' || slug == '${k}s',
+      orElse: () => 'terms',
+    );
+    return _documents[key]!;
+  }
 
   @override
   Widget build(BuildContext context) {
+    final doc = _resolveDocument();
+    _openUrl(doc.url);
     return Scaffold(
-      appBar: AppBar(title: const Text('Legal')),
-      body: ListView.separated(
-        padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
-        itemBuilder: (context, index) {
-          final section = _legalSections[index];
-          return _LegalCard(title: section['title']!, body: section['body']!);
-        },
-        separatorBuilder: (_, __) => const SizedBox(height: 16),
-        itemCount: _legalSections.length,
+      appBar: AppBar(title: Text(doc.title)),
+      body: const Center(
+        child: Text('Opening...'),
       ),
     );
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    try {
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!launched) {
+        _showError();
+      }
+    } catch (_) {
+      _showError();
+    }
+  }
+
+  void _showError() {
+    if (Get.context != null) {
+      ScaffoldMessenger.of(Get.context!).showSnackBar(
+        const SnackBar(content: Text('Could not open this link. Please try again.')),
+      );
+    }
   }
 }
 
-class _LegalCard extends StatelessWidget {
-  const _LegalCard({required this.title, required this.body});
+class _LegalDocument {
+  const _LegalDocument({required this.title, required this.url});
 
   final String title;
-  final String body;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Card(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              title,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              body,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  final String url;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     source: hosted
     version: "9.0.0"
   app_links:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: app_links
       sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
@@ -544,6 +544,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1012,6 +1020,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.26.1"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   geolocator: ^14.0.2
   geocoding: ^4.0.0
   permission_handler: ^12.0.1
+  flutter_markdown: ^0.7.7+1
   webview_flutter: ^4.8.0
   webview_flutter_android: ^4.10.2
   webview_flutter_wkwebview: ^3.23.0
@@ -62,6 +63,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   maplibre_gl: 0.26.1
   flutter_secure_storage: ^10.0.0
+  app_links: ^6.4.1
   firebase_core: ^4.1.1
   firebase_messaging: ^16.0.2
   firebase_crashlytics: ^5.0.6


### PR DESCRIPTION
Update AndroidManifest, routes, deep links, profile views, and add deep link service.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/stays-app/pull/5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cross-platform deep linking for listings and chat with a new `DeepLinkService`, plus public routes for shared links. Also updates legal/privacy flows and adds a double‑back exit on Home.

- **New Features**
  - Deep links: Android intent-filters and iOS URL types + associated domains for https `the360ghar.com` (and subdomains) and `stays360://`. Supports `/stays/listing/:id` and `/stays/chat/:conversationId` (initial link + live stream).
  - Routes: Added `Routes.listingDeepLink` and `Routes.chatDeepLink` with public access; navigation via `Get.toNamed`.
  - Legal/Privacy: LegalView opens external URLs for Terms and Privacy. Replaced account deletion API with a mailto flow to support; removed `deleteAccount` from provider/repository.
  - UX: Added “press back again to exit” on the home view.
  - Permissions: Added camera, microphone, and photo library permissions with user-facing reasons.

- **Dependencies**
  - Added `app_links` for deep links.
  - Added `flutter_markdown` (prep for richer legal content).

<sup>Written for commit 79be97858b1dbecdbc2b07e1f9ea49bcfe3cda69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/stays-app/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds deep link support (Android App Links + iOS Universal Links + custom `stays360://` scheme), registers a `DeepLinkService`, adds camera/microphone/photo permissions, refactors account deletion to an email-based flow, and replaces the inline `LegalView` content with an external URL launcher.

- **Deep link infrastructure**: `DeepLinkService` handles initial and live URI streams, maps HTTPS/custom-scheme links to internal GetX routes, and stores a pending link for post-login replay. Android and iOS platform configs are updated accordingly.
- **Route conflict**: `Routes.listingDeepLink` and `Routes.chatDeepLink` are assigned the same string values as `Routes.listingDetail` and `Routes.chat`, causing the intended public (unauthenticated) `GetPage` entries to be shadowed by the already-registered auth-protected pages.
- **`LegalView` regression**: `_openUrl` is called directly inside `build()`, so `launchUrl` fires on every widget rebuild. The binding also passes an undeclared `usersProvider:` argument to `PrivacyController`, which is a compile-time error preventing the app from building.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the app will not compile due to a mismatch between the binding and the controller constructor.

The binding passes `usersProvider:` to `PrivacyController`, which does not declare that parameter, producing a Dart compile error. Additionally, the new public deep link routes share the same path strings as the existing auth-protected routes, so they are never reached. The `LegalView` also calls `launchUrl` on every widget rebuild. These three issues together mean the feature does not work as intended and the project won't build in its current state.

`profile_binding.dart` (compile error), `app_routes.dart` + `app_pages.dart` (route conflict), and `legal_view.dart` (repeated URL launch in `build`).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/features/profile/bindings/profile_binding.dart | Passes `usersProvider:` to `PrivacyController` constructor, which does not declare that parameter — causes a compile-time error. |
| lib/app/routes/app_routes.dart | New `listingDeepLink` and `chatDeepLink` constants are identical strings to existing `listingDetail` and `chat`, making the public deep link routes unreachable in GetX. |
| lib/features/profile/views/legal_view.dart | Replaced inline content with an external URL launcher, but `_openUrl` is invoked directly inside `build()`, causing `launchUrl` to fire on every widget rebuild. |
| lib/app/data/services/deep_link_service.dart | New service handles initial and live deep links via `app_links`, maps URLs to internal paths, and stores a pending link for post-login replay. Implementation is sound but the routes it navigates to are auth-protected due to the duplicate route name issue. |
| lib/features/profile/controllers/privacy_controller.dart | Account deletion changed from a direct API call to opening a `mailto:` link; has an unused `UsersProvider` import and minor constructor indentation regression. |
| ios/Runner/Runner.entitlements | New entitlements file adds Associated Domains for Universal Links and push notifications, but `aps-environment` is hardcoded to `development`, which will break push delivery in production/App Store builds. |
| android/app/src/main/AndroidManifest.xml | Adds camera, audio, and media permissions plus App Links intent filters for `https` and a custom `stays360://` scheme; looks correct. |
| lib/app/routes/app_pages.dart | Registers two new public GetPages for deep links, but because their route names are identical to existing auth-protected pages, they are effectively dead registrations. |
| lib/app/data/providers/users_provider.dart | Removes `deleteAccount` API method; straightforward deletion aligned with the new email-based flow. |
| lib/app/data/repositories/profile_repository.dart | Removes `deleteAccount` repository method to match provider change; no issues. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OS as OS / Browser
    participant DLS as DeepLinkService
    participant GetX as GetX Router
    participant AM as AuthMiddleware
    participant View as ListingDetailView / ChatView

    OS->>DLS: Incoming URI (https or stays360://)
    DLS->>DLS: _mapToInternalPath(uri)
    DLS->>DLS: _navigateToPath(path) — stores pendingDeepLink
    DLS->>GetX: Get.toNamed("/listing/:id")
    GetX->>AM: Route match → AuthMiddleware (first registered)
    alt User authenticated
        AM->>View: Allow navigation
    else Unauthenticated
        AM->>GetX: Redirect to /login
        Note over DLS,GetX: pendingDeepLink preserved for post-login replay
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/features/profile/bindings/profile_binding.dart`, line 113-124 ([link](https://github.com/360ghar/stays-app/blob/79be97858b1dbecdbc2b07e1f9ea49bcfe3cda69/lib/features/profile/bindings/profile_binding.dart#L113-L124)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> **Compile-time error: `usersProvider` is not a constructor parameter**

   `PrivacyController`'s constructor declares only four required parameters (`profileRepository`, `profileController`, `authRepository`, `authController`). The binding now passes a fifth named argument `usersProvider:` that does not exist in the constructor, so the project will not compile. The `UsersProvider` import was added to `privacy_controller.dart` but no corresponding field or constructor parameter was defined there — likely an incomplete refactor.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Update AndroidManifest, routes, deep lin..."](https://github.com/360ghar/stays-app/commit/79be97858b1dbecdbc2b07e1f9ea49bcfe3cda69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35986927)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->